### PR TITLE
Feat: Improve reset password page UI/UX (Issue #211)

### DIFF
--- a/src/views/pages/reset-password.ejs
+++ b/src/views/pages/reset-password.ejs
@@ -1,43 +1,257 @@
-<% layout("/layouts/boilerplate") -%>
+<%- layout("/layouts/boilerplate") -%>
+
 <style>
-    .btn {
-        width: 100%;
-        padding: 15px 25px;
-        background: linear-gradient(90deg, #4e00ff, #8e00ff);
-        border: none;
-        border-radius: 25px;
-        color: #fff;
-        font-size: 18px;
-        font-weight: bold;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        box-shadow: 0 5px 15px rgba(78, 0, 255, 0.5);
+  .reset-password-card {
+    max-width: 450px; /* Reduced card width */
+    margin: 60px auto; /* Center the card */
+    padding: 30px; /* Added padding */
+    border-radius: 12px; /* Softer corners */
+    background: rgba(30, 30, 60, 0.6); /* Semi-transparent dark background */
+    border: 1px solid rgba(142, 0, 255, 0.18);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  }
+  .reset-password-card h3 {
+    text-align: center;
+    margin-bottom: 25px;
+    color: #fff;
+  }
+  .form-label {
+    color: #b2bec3; /* Lighter label color */
+    margin-bottom: 8px; /* Space below label */
+  }
+  .form-control {
+    background-color: rgba(255, 255, 255, 0.05); /* Slightly transparent input */
+    border: 1px solid rgba(142, 0, 255, 0.2);
+    color: #fff;
+    border-radius: 8px; /* Rounded inputs */
+    padding: 12px 15px; /* Comfortable input padding */
+  }
+  .form-control:focus {
+    background-color: rgba(255, 255, 255, 0.08);
+    border-color: rgba(142, 0, 255, 0.5);
+    box-shadow: 0 0 0 0.2rem rgba(142, 0, 255, 0.25);
+    color: #fff;
+  }
+  .password-wrapper {
+    position: relative; /* Needed for the eye icon positioning */
+  }
+  .toggle-password {
+    position: absolute;
+    right: 15px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+    color: #b2bec3; /* Muted icon color */
+  }
+  .password-rules {
+    font-size: 0.8rem;
+    color: #b2bec3;
+    margin-top: 5px;
+  }
+  /* --- Strength Meter Styles --- */
+  .strength-meter-container { 
+     height: 5px;
+     background: rgba(255, 255, 255, 0.1); /* Faint background bar */
+     border-radius: 5px;
+     margin-top: 8px;
+     overflow: hidden; /* Keep the colored bar inside */
+  }
+  .strength-meter {
+     height: 100%;
+     width: 0%; /* Start at 0% width */
+     background-color: #ccc; /* Default color */
+     border-radius: 5px;
+     transition: width 0.3s ease, background-color 0.3s ease; /* Smooth transition */
+  }
+  /* --- End Strength Meter Styles --- */
+  .validation-message { /* Placeholder style */
+    color: #f97373; /* Red for errors */
+    font-size: 0.8rem;
+    margin-top: 4px;
+    display: none; /* Hidden by default */
+  }
+  .btn-reset {
+    width: auto; /* Button width to content */
+    padding: 10px 25px; /* Reduced button padding */
+    background: linear-gradient(90deg, #4e00ff, #8e00ff);
+    border: none;
+    border-radius: 25px;
+    color: #fff;
+    font-size: 1rem; /* Slightly smaller font */
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 5px 15px rgba(78, 0, 255, 0.4);
+    display: block; /* Center button */
+    margin: 25px auto 15px auto; /* Center button */
+  }
+  .btn-reset:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 20px rgba(142, 0, 255, 0.6);
+  }
+  .back-link {
+    display: block;
+    text-align: center;
+    font-size: 0.9rem;
+    color: #b2bec3;
+    text-decoration: none;
+    margin-top: 20px;
+  }
+  .back-link:hover {
+    color: #fff;
+    text-decoration: underline;
+  }
+  /* Responsive */
+   @media (max-width: 576px) {
+    .reset-password-card {
+      width: 90%; /* Card width on small screens */
+      margin: 30px auto;
+      padding: 20px;
     }
-
-    .btn:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 10px 25px rgba(142, 0, 255, 0.7);
-    }
-
-    .form-box {
-        margin-top: 60px;
-    }
+  }
 </style>
 
-<div class="frm_container row">
-    <div class="col-md-4 offset-md-4 frm_box form-box">
-        <h3>Set New Password</h3>
-        <form method="POST" action="/api/users/reset-password">
-            <input type="hidden" name="token" value="<%= token %>">
-            <div class="mb-3">
-                <label for="password" class="form-label">New Password</label>
-                <input type="password" class="form-control" id="password" name="password" required>
-            </div>
-            <div class="mb-3">
-                <label for="confirmPassword" class="form-label">Confirm Password</label>
-                <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required>
-            </div>
-            <button type="submit" class="btn">Reset Password</button>
-        </form>
-    </div>
+<div class="container"> 
+  <div class="card reset-password-card">
+    <h3>Set New Password</h3>
+    <form id="resetPasswordForm" method="POST" action="/api/users/reset-password" novalidate>
+      <input type="hidden" name="token" value="<%= token %>">
+
+      <div class="mb-3">
+        <label for="password" class="form-label">Enter New Password</label>
+        <div class="password-wrapper">
+          <input type="password" class="form-control" id="password" name="password" required>
+          <span class="toggle-password"><i class="fas fa-eye"></i></span> 
+        </div>
+        <div class="strength-meter-container"> 
+            <div class="strength-meter" id="passwordStrengthMeter"></div> 
+        </div>
+        <p class="password-rules">
+          Must be 8+ characters, include uppercase, number, and special character.
+        </p>
+        <div class="validation-message" id="passwordError"></div> 
+      </div>
+
+      <div class="mb-3">
+        <label for="confirmPassword" class="form-label">Confirm New Password</label>
+        <div class="password-wrapper">
+          <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required>
+           <span class="toggle-password"><i class="fas fa-eye"></i></span>
+        </div>
+        <div class="validation-message" id="confirmPasswordError"></div> 
+      </div>
+
+      <button type="submit" class="btn btn-reset">Reset Password</button>
+
+      <a href="/login" class="back-link">Back to Login</a>
+    </form>
+  </div>
 </div>
+
+<script>
+  // This code runs after the page is loaded
+  document.addEventListener('DOMContentLoaded', function() {
+    
+    // --- Password Visibility Toggle (Corrected) ---
+    const togglePasswordButtons = document.querySelectorAll('.toggle-password'); 
+
+    togglePasswordButtons.forEach(button => {
+      button.addEventListener('click', function() {
+        // Find the password input field right BEFORE the span containing the icon
+        const passwordInput = this.previousElementSibling; 
+        const icon = this.querySelector('i'); // Find the <i> tag (the actual icon)
+
+        if (passwordInput.getAttribute('type') === 'password') {
+          passwordInput.setAttribute('type', 'text');
+          icon.classList.remove('fa-eye');
+          icon.classList.add('fa-eye-slash');
+        } else {
+          passwordInput.setAttribute('type', 'password');
+          icon.classList.remove('fa-eye-slash');
+          icon.classList.add('fa-eye');
+        }
+      });
+    });
+    // --- End of Password Visibility Toggle ---
+
+    // --- Password Strength Meter Logic (Added) ---
+    const passwordInput = document.getElementById('password');
+    const strengthMeter = document.getElementById('passwordStrengthMeter');
+    
+    passwordInput.addEventListener('input', function() {
+      const password = passwordInput.value;
+      let strength = 0;
+
+      // Basic strength checks
+      if (password.length >= 8) strength++; 
+      if (/[A-Z]/.test(password)) strength++; 
+      if (/[0-9]/.test(password)) strength++; 
+      if (/[^A-Za-z0-9]/.test(password)) strength++; 
+
+      // Update strength meter UI
+      strengthMeter.style.width = (strength * 25) + '%'; 
+      
+      if (strength === 0 && password.length > 0) { // Show red if not empty but fails all checks
+        strengthMeter.style.backgroundColor = '#f97373'; 
+      } else if (strength === 1) {
+        strengthMeter.style.backgroundColor = '#f97373'; // Red for weak
+      } else if (strength === 2) {
+        strengthMeter.style.backgroundColor = '#f59e0b'; // Orange for medium
+      } else if (strength === 3) {
+        strengthMeter.style.backgroundColor = '#3b82f6'; // Blue for strong
+      } else if (strength === 4) { // Only green if all 4 conditions met
+        strengthMeter.style.backgroundColor = '#10b981'; // Green for very strong
+      } else { // Handles empty case or initial state
+         strengthMeter.style.backgroundColor = '#ccc'; // Grey for empty/default
+      }
+    });
+    // --- End of Strength Meter Logic ---
+
+    // --- Final Validation Logic ---
+    const form = document.getElementById('resetPasswordForm');
+    const confirmPasswordInput = document.getElementById('confirmPassword');
+    const confirmPasswordError = document.getElementById('confirmPasswordError');
+    // We already have passwordInput and passwordError from the strength meter logic
+
+    form.addEventListener('submit', function(event) {
+      let isValid = true; // Assume the form is valid initially
+
+      // 1. Check Password Strength/Rules again (using the strength calculated earlier)
+      const currentPassword = passwordInput.value;
+      let currentStrength = 0;
+      if (currentPassword.length >= 8) currentStrength++;
+      if (/[A-Z]/.test(currentPassword)) currentStrength++;
+      if (/[0-9]/.test(currentPassword)) currentStrength++;
+      if (/[^A-Za-z0-9]/.test(currentPassword)) currentStrength++;
+
+      if (currentStrength < 4) { // Check if all rules are met
+        passwordError.textContent = 'Password does not meet all requirements.';
+        passwordError.style.display = 'block';
+        passwordInput.focus(); // Focus on the field with the error
+        isValid = false; // Mark form as invalid
+      } else {
+        passwordError.style.display = 'none'; // Hide error if valid
+      }
+
+      // 2. Check if Passwords Match
+      if (passwordInput.value !== confirmPasswordInput.value) {
+        confirmPasswordError.textContent = 'Passwords do not match.';
+        confirmPasswordError.style.display = 'block';
+        if (isValid) confirmPasswordInput.focus(); // Only focus here if the first password was okay
+        isValid = false; // Mark form as invalid
+      } else {
+        confirmPasswordError.style.display = 'none'; // Hide error if they match
+      }
+
+      // If anything failed, prevent form submission
+      if (!isValid) {
+        event.preventDefault(); // Stop the form from submitting to the server
+        event.stopPropagation(); // Stop any other potential handlers
+      }
+      // If isValid is still true, the form will submit normally
+    });
+    // --- End of Validation Logic ---
+    // (We will add the "passwords match" check here next)
+    // ---------------------------------------------
+  });
+</script>


### PR DESCRIPTION
📄 Description
This PR improves the UI and UX of the "Set New Password" page (reset-password.ejs) based on the requirements in issue #211. It makes the page cleaner, more user-friendly, and provides better security feedback.

This PR includes:

[x] Adds: Password visibility toggle (eye icon) functionality.
[x] Adds: Password strength meter (visual bar).
[x] Adds: Front-end validation (password rules check, password match check).
[x] Updates: The overall layout and styling of the reset password card and form elements.

🔗 Related Issues
Fixes #211

✨ Changes Summary
Modified views/users/reset-password.ejs:
Updated the HTML structure to use a cleaner card layout (.reset-password-card).
Added <span> elements with Font Awesome icons (<i class="fas fa-eye"></i>) for password visibility toggles.
Added a <div> structure (.strength-meter-container > .strength-meter) for the password strength indicator.
Added <p class="password-rules"> helper text.
Added empty <div class="validation-message"> elements for displaying front-end errors.
Added a "Back to Login" link.
Added a <script> block containing JavaScript for:
Password visibility toggle functionality.
Password strength calculation and meter UI update.
Form submission validation (checking strength and password match).
Modified CSS within reset-password.ejs (<style> block):
Added styles for the new card layout (.reset-password-card), form elements (.form-control, .form-label), password wrapper (.password-wrapper), toggle icon (.toggle-password), helper text (.password-rules), strength meter (.strength-meter-container, .strength-meter), validation messages (.validation-message), button (.btn-reset), and back link (.back-link).
Added basic responsive styles (@media) for smaller screens.

📸 Screenshots (if applicable)

....


✅ Checklist
Please check all that apply before submitting your pull request:

[x] I have performed a self-review of my code
[ ] I have commented code in hard-to-understand areas (Self-assess if needed)
[x] My changes generate no new warnings
[x] I am submitting this PR as a GSSOC’25 contributor
[ ] I am submitting this PR as a GSSOC’25 contributor
